### PR TITLE
ES6: add es6 to backend for modern code development going forward

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,13 +14,15 @@
   "homepage": "http://kinotimes.tk",
   "private": true,
   "scripts": {
-    "start": "app/server.js",
-    "start-dev": "nodemon -L app/server.js",
-    "initialData": "node core/getFilmsJob.js --days 1"
+    "start": "babel-node app/server.js",
+    "start-dev": "nodemon -L app/server.js --exec babel-node",
+    "initialData": "babel-node core/getFilmsJob.js --days 2"
   },
   "dependencies": {
     "apicache": "^1.2.3",
     "async": "^2.6.1",
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "express": "^4.16.3",

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -48,8 +48,8 @@ var logger = new winston.Logger({
 });
 
 var Logger = function(){
-	path = stackTrace.get()[1].getFileName();
-	codePath = path.replace(/^.*[\\\/]/, '');
+	var pathToFile = stackTrace.get()[1].getFileName();
+	codePath = pathToFile.replace(/^.*[\\\/]/, '');
 	return logger;
 }
 


### PR DESCRIPTION
I found myself not being able to follow any of the code examples for using graphql :/

note: it looks like `npm run ...` will be a good option for executing the initial steps of setting up the data